### PR TITLE
Enhanced samples for making a spreadsheet of users

### DIFF
--- a/agoTools/utilities.py
+++ b/agoTools/utilities.py
@@ -222,6 +222,16 @@ class Utilities:
         request = self.user.portalUrl + '/sharing/rest/content/users/' + userName + '?' + parameters
         userContent = json.loads(urllib.urlopen(request).read())
         return userContent['folders']
+    
+    def getUserGroups(self, username=None):
+        '''
+        Returns all groups for the specified user.'''
+        if username == None:
+            username = self.user.username
+        parameters = urllib.urlencode({'token': self.user.token, 'f': 'json'})
+        request = self.user.portalUrl + '/sharing/rest/community/users/' + username + '?' + parameters
+        response = json.loads(urllib.urlopen(request).read())
+        return response['groups']
 
     def getFolderID(self, folderTitle, userName=None):
         '''

--- a/samples/createUserListCSV.py
+++ b/samples/createUserListCSV.py
@@ -3,23 +3,33 @@ import csv, time
 from agoTools.admin import Admin
 
 agoAdmin = Admin('<username>') # Replace <username> with your admin username.
+outputFile = 'c:/temp/users.csv'
+
 users = agoAdmin.getUsers()
 roles = agoAdmin.getRoles()
+
 #Make a dictionary of the roles so we can convert custom roles from their ID to their associated name.
 roleLookup = {}
 for role in roles:
     roleLookup[role["id"]] = role["name"]
 
-outputFile = 'c:/temp/users.csv'
-
 with open(outputFile, 'wb') as output:
-    dataWriter = csv.writer(output, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+    dataWriter = csv.writer(output, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
     # Write header row.
-    #Groups apparently doesn't work...I'll leave it in so it'll work when it gets implemented. I could make a rest call for each user but that'll take awhile...
-    dataWriter.writerow(['Full Name', 'Email', 'Username', 'Role', 'Date Created','Groups'])
+    dataWriter.writerow(['Full Name',
+                         'Email',
+                         'Username',
+                         'Role',
+                         'Date Created'])
     # Write user data.
     for user in users:
         #get role name from the id. If it's not in the roles, it's one of the standard roles so just use it.
         roleID = user['role']
         roleName = roleLookup.get(roleID,roleID)
-        dataWriter.writerow([user['fullName'].encode('utf-8'), user['email'].encode('utf-8'), user['username'].encode('utf-8'), roleName, time.strftime("%Y-%m-%d",time.gmtime(user['created']/1000)),",".join(user['groups'])])
+        dataWriter.writerow([user['fullName'].encode('utf-8'),
+                             user['email'].encode('utf-8'),
+                             user['username'].encode('utf-8'),
+                             roleName,
+                             time.strftime("%Y-%m-%d",time.gmtime(user['created']/1000))])
+        
+print('Finished writing spreadsheet {}'.format(outputFile))

--- a/samples/createUserListWithGroups.py
+++ b/samples/createUserListWithGroups.py
@@ -1,0 +1,65 @@
+### This script creates a spreadsheet with key informationa about each user.
+### It expands on createUserListCSV.py by adding a field detailing the groups
+### each user is a member of.
+
+# Requires admin role.
+import csv, time
+from agoTools.admin import Admin
+from agoTools.utilities import Utilities
+
+username = '<username>'
+password = '<password>'
+outputFile = 'c:/temp/users.csv'
+
+agoAdmin = Admin(username=username, password=password)
+agoUtilities = Utilities(username=username, password=password)
+
+print('Getting users.')
+users = agoAdmin.getUsers()
+roles = agoAdmin.getRoles()
+# Make a dictionary of the roles so we can convert custom roles from their ID to their associated name.
+roleLookup = {}
+for role in roles:
+    roleLookup[role["id"]] = role['name']
+
+# Get the users' groups.
+print('Getting each user\'s groups.')
+for user in users:
+    user['groups'] = []
+    groups = agoUtilities.getUserGroups(user['username'])
+    for group in groups:
+        user['groups'].append(group['title'].encode('utf-8'))
+
+print('Writing the results.')
+with open(outputFile, 'wb') as output:
+    dataWriter = csv.writer(output, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
+    # Write header row.
+    dataWriter.writerow(['Full Name',
+                         'Email',
+                         'Username',
+                         'Role',
+                         'Date Created',
+                         'Last Login',
+                         'Groups'])
+
+    # Write user data.
+    for user in users:
+        try:
+            # Get role name from the id. If it's not in the roles, it's one of the standard roles so just use it.
+            roleID = user['role']
+            roleName = roleLookup.get(roleID, roleID)
+            if user['lastLogin'] > 0:
+                lastLogin = time.strftime("%Y-%m-%d", time.gmtime(user['lastLogin']/1000))
+            else:
+                lastLogin = 'Never'
+            dataWriter.writerow([user['fullName'].encode('utf-8'),
+                                 user['email'].encode('utf-8'),
+                                 user['username'].encode('utf-8'),
+                                 roleName,
+                                 time.strftime("%Y-%m-%d", time.gmtime(user['created']/1000)),
+                                 lastLogin,
+                                 ','.join(user['groups'])])
+        except:
+            print('Problem writing data for {}'.format(user['username']))
+
+print('Finished writing spreadsheet {}'.format(outputFile))


### PR DESCRIPTION
`createUserListCSV.py` contained a reference to groups not working. This was because groups are not returned as part of the default user search. I added a helper function to look up a user's groups and created a new sample (createUserListWithGroups.py) to expand the spreadsheet to include them in the output.

Since this example requires making an additional call to each user, it may take a while to run depending on the size of your org.