### PR TITLE
update getGroups for situations with >100 groups

### DIFF
--- a/agoTools/admin.py
+++ b/agoTools/admin.py
@@ -68,6 +68,7 @@ class Admin:
         for group in groups['results']:
             allGroups.append(group)
         while groups['nextStart'] > 0:
+            groups = self.__groups__(groups['nextStart'])
             for group in groups['results']:
                 allGroups.append(group)
         return allGroups


### PR DESCRIPTION
in a Portal with >100 groups, this function would run indefinitely and generate massive objects in memory. I added a line to the While loop to correct this.